### PR TITLE
Rework otlp metrics

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 dockers:
   - id: backend-amd64

--- a/pkg/cmd/server/grpc/grpc_server.go
+++ b/pkg/cmd/server/grpc/grpc_server.go
@@ -223,7 +223,9 @@ func (s *grpcServer) SetupDb() {
 
 func (s *grpcServer) SetupGrpcServices() {
 	s.mux = http.NewServeMux()
-	s.otel, _ = otelconnect.NewInterceptor()
+	s.otel, _ = otelconnect.NewInterceptor(
+		otelconnect.WithoutServerPeerAttributes(),
+	)
 	staleDuration, err := time.ParseDuration(config.StaleDuration)
 	if err != nil {
 		staleDuration = 1 * time.Minute


### PR DESCRIPTION
Fixes #240

## Description

- removed peer information
- included host,container.id from builtins
- service.instance.id is hostname by default
